### PR TITLE
fix: switch to downloading from Filecoin Saturn

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -103,7 +103,7 @@ function cleanArguments (version, platform, arch, installPath) {
     cwd: process.env.INIT_CWD || process.cwd(),
     defaults: {
       version: version || latest,
-      distUrl: 'https://ipfs.io'
+      distUrl: 'https://strn.pl'
     }
   })
 


### PR DESCRIPTION
[Filecoin Saturn](https://strn.network/)'s http gateway is like ipfs.io, just with caching so it should prevent the [intermittant CI failures](https://github.com/libp2p/js-libp2p/actions/runs/4105171858/jobs/7081659680) we sometimes see.