### PR TITLE
feat: Simple makefile to generate binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ package-lock.json
 # Where the binaries go
 go-ipfs
 p2pd
+bin/*.zip
+bin/*.tar.gz
+bin/go-libp2p-daemon
+bin/p2pd-*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+COMMIT?=master
+TARGETS=linux darwin
+WORKDIR=bin
+
+all: $(WORKDIR)/p2pd-linux.tar.gz $(WORKDIR)/p2pd-darwin.tar.gz $(WORKDIR)/p2pd-win32.zip
+
+$(WORKDIR)/go-libp2p-daemon:
+	mkdir -p bin/go-libp2p-daemon
+
+clone: $(WORKDIR)/go-libp2p-daemon
+	git clone https://github.com/libp2p/go-libp2p-daemon.git bin/go-libp2p-daemon && cd $(WORKDIR)/go-libp2p-daemon && git checkout $(COMMIT)
+
+$(TARGETS): clone
+	cd bin/go-libp2p-daemon/p2pd && GOOS=$@ go build -o p2pd-$@ && mv p2pd-$@ ../../
+
+$(WORKDIR)/p2pd-linux.tar.gz: linux
+	tar -czf $@ $(WORKDIR)/p2pd-linux
+
+$(WORKDIR)/p2pd-darwin.tar.gz: darwin
+	tar -czf $@ $(WORKDIR)/p2pd-darwin
+
+win32:
+	cd $(WORKDIR)/go-libp2p-daemon/p2pd && GOOS=windows GOARCH=386 go build -o p2pd-$@ && mv p2pd-$@ ../../
+
+$(WORKDIR)/p2pd-win32.zip: win32
+	zip $@ $(WORKDIR)/p2pd-win32
+
+clean:
+	rm -rf bin/go-libp2p-daemon *.tar.gz *.zip
+
+.PHONY: clean


### PR DESCRIPTION
Adds a makefile which does the following:
1. Clone `go-libp2p-daemon`.
2. Checkout given commit (default to master).
3. Build linux x64, darwin x64, and windows i386 binaries for p2pd.
4. Compress with tar.gz and zip.