### PR TITLE
feat: update go-libp2p-daemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,11 @@ $(WORKDIR)/go-libp2p-daemon:
 clone: $(WORKDIR)/go-libp2p-daemon
 	git clone https://github.com/libp2p/go-libp2p-daemon.git bin/go-libp2p-daemon; cd $(WORKDIR)/go-libp2p-daemon && git checkout $(COMMIT)
 
-$(TARGETS): clone
+darwin: clone
 	cd bin/go-libp2p-daemon/p2pd && GOOS=$@ go build -o p2pd-$@ && mv p2pd-$@ ../../
+
+linux: clone
+	cd bin/go-libp2p-daemon/p2pd && GOARCH=amd64 GOOS=$@ go build -o p2pd-$@ && mv p2pd-$@ ../../
 
 $(WORKDIR)/p2pd-linux.tar.gz: linux
 	tar -czf $@ $(WORKDIR)/p2pd-linux

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ $(WORKDIR)/go-libp2p-daemon:
 	mkdir -p bin/go-libp2p-daemon
 
 clone: $(WORKDIR)/go-libp2p-daemon
-	git clone https://github.com/libp2p/go-libp2p-daemon.git bin/go-libp2p-daemon && cd $(WORKDIR)/go-libp2p-daemon && git checkout $(COMMIT)
+	git clone https://github.com/libp2p/go-libp2p-daemon.git bin/go-libp2p-daemon; cd $(WORKDIR)/go-libp2p-daemon && git checkout $(COMMIT)
 
 $(TARGETS): clone
 	cd bin/go-libp2p-daemon/p2pd && GOOS=$@ go build -o p2pd-$@ && mv p2pd-$@ ../../
@@ -20,7 +20,7 @@ $(WORKDIR)/p2pd-darwin.tar.gz: darwin
 	tar -czf $@ $(WORKDIR)/p2pd-darwin
 
 win32:
-	cd $(WORKDIR)/go-libp2p-daemon/p2pd && GOOS=windows GOARCH=386 go build -o p2pd-$@ && mv p2pd-$@ ../../
+	cd $(WORKDIR)/go-libp2p-daemon/p2pd && GOOS=windows GOARCH=386 go build -o p2pd-$@.exe && mv p2pd-$@.exe ../../
 
 $(WORKDIR)/p2pd-win32.zip: win32
 	zip $@ $(WORKDIR)/p2pd-win32

--- a/src/download.js
+++ b/src/download.js
@@ -27,7 +27,7 @@ const os = require('os')
  * avoid expensive fetch if file is already in cache
  * @param {string} url
  */
-async function cachingFetchAndVerify(url) {
+async function cachingFetchAndVerify (url) {
   const cacheDir = process.env.NPM_GO_LIBP2P_CACHE || cachedir('npm-go-libp2p')
   const filename = url.split('/').pop()
 
@@ -70,7 +70,7 @@ async function cachingFetchAndVerify(url) {
  * @param {string} installPath
  * @param {import('stream').Readable} stream
  */
-function unpack(url, installPath, stream) {
+function unpack (url, installPath, stream) {
   return new Promise((resolve, reject) => {
     if (url.endsWith('.zip')) {
       return stream.pipe(
@@ -98,7 +98,7 @@ function unpack(url, installPath, stream) {
  * @param {string} [arch]
  * @param {string} [installPath]
  */
-function cleanArguments(version, platform, arch, installPath) {
+function cleanArguments (version, platform, arch, installPath) {
   const conf = pkgConf.sync('go-libp2p', {
     cwd: process.env.INIT_CWD || process.cwd(),
     defaults: {
@@ -122,7 +122,7 @@ function cleanArguments(version, platform, arch, installPath) {
  * @param {string} arch
  * @param {string} distUrl
  */
-async function getDownloadURL(version, platform, arch, distUrl) {
+async function getDownloadURL (version, platform, arch, distUrl) {
   const versionData = versions[version]
 
   if (versionData == null) {
@@ -150,7 +150,7 @@ async function getDownloadURL(version, platform, arch, distUrl) {
  * @param {string} options.installPath
  * @param {string} options.distUrl
  */
-async function download({ version, platform, arch, installPath, distUrl }) {
+async function download ({ version, platform, arch, installPath, distUrl }) {
   const url = await getDownloadURL(version, platform, arch, distUrl)
   const data = await cachingFetchAndVerify(url)
 
@@ -181,7 +181,7 @@ async function findBin({ installPath, platform }) {
  * @param {object} options
  * @param {string} options.depBin
  */
-async function link({ depBin }) {
+async function link ({ depBin }) {
   let localBin = path.resolve(path.join(__dirname, '..', 'bin', 'p2pd'))
 
   if (isWin) {

--- a/src/download.js
+++ b/src/download.js
@@ -58,7 +58,7 @@ async function cachingFetchAndVerify(url) {
   if (calculatedSha !== filename) {
     console.log(`Expected CID: ${filename}`)
     console.log(`Actual   CID: ${calculatedSha}`)
-    throw new Error(`SHA512 of ${cachedFilePath}' (${calculatedSha}) does not match expected value from ${cachedFilePath}`)
+    throw new Error(`SHA256 of ${cachedFilePath}' (${calculatedSha}) does not match expected value from ${cachedFilePath}`)
   }
   console.log(`OK ${calculatedSha}`)
 

--- a/src/download.js
+++ b/src/download.js
@@ -58,7 +58,7 @@ async function cachingFetchAndVerify (url) {
   if (calculatedSha !== filename) {
     console.log(`Expected CID: ${filename}`)
     console.log(`Actual   CID: ${calculatedSha}`)
-    throw new Error(`SHA256 of ${cachedFilePath}' (${calculatedSha}) does not match expected value from ${cachedFilePath}`)
+    throw new Error(`CID of ${cachedFilePath}' (${calculatedSha}) does not match expected value from ${cachedFilePath}`)
   }
   console.log(`OK ${calculatedSha}`)
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,9 @@ const path = require('path')
 module.exports.path = function () {
   const paths = [
     path.resolve(path.join(__dirname, '..', 'p2pd')),
-    path.resolve(path.join(__dirname, '..', 'p2pd.exe'))
+    path.resolve(path.join(__dirname, '..', 'p2pd.exe')),
+    path.resolve(path.join(__dirname, '..', 'bin/p2pd')),
+    path.resolve(path.join(__dirname, '..', 'bin/p2pd.exe')),
   ]
 
   for (const bin of paths) {

--- a/src/versions.js
+++ b/src/versions.js
@@ -13,6 +13,11 @@
  * @type {Record<string, Version>}
  */
 const versions = {
+  'v0.12.0': {
+    darwin: 'QmRWDoPsw6a5eTCMCA3GAnwWjGXFz1URNn9obvcxrypP4W',
+    linux: 'QmQDjWkPejcfj8NuafB59tLubKXfCECgGTY1ayV5qjp7QR',
+    win32: 'QmYrYKthxvoFZnLFP1hJX7BFTvQgoSip3mwNNuaKDZ3VTU'
+  },
   'v0.11.0': {
     darwin: 'QmbRgQrwZFyR6cjwuN6dgSfadmr9KrLmM72hRJ1B3K6659',
     linux: 'QmW6hANCx63LR2Unb8TWwB7UkDC2SNKUV5QbaWzSyjsoPf',
@@ -52,6 +57,6 @@ const versions = {
 }
 
 module.exports = {
-  latest: 'v0.11.0',
+  latest: 'v0.12.0',
   versions
 }

--- a/src/versions.js
+++ b/src/versions.js
@@ -15,7 +15,7 @@
 const versions = {
   'v0.12.0': {
     darwin: 'QmRWDoPsw6a5eTCMCA3GAnwWjGXFz1URNn9obvcxrypP4W',
-    linux: 'QmQDjWkPejcfj8NuafB59tLubKXfCECgGTY1ayV5qjp7QR',
+    linux: 'QmSMiiCCmu4YGdDfJL8cpbEeDtUGUULnvHtTBCeio8zbe7',
     win32: 'QmYrYKthxvoFZnLFP1hJX7BFTvQgoSip3mwNNuaKDZ3VTU'
   },
   'v0.11.0': {

--- a/test/fixtures/clean.js
+++ b/test/fixtures/clean.js
@@ -4,11 +4,15 @@ const fs = require('fs/promises')
 const path = require('path')
 const execa = require('execa')
 
-module.exports = async function clean () {
+module.exports = async function clean() {
   await fs.rm(path.resolve(__dirname, '../../p2pd')).catch(err => {
     if (err.code !== 'ENOENT') {
       throw err
     }
   })
-  await execa('git', ['checkout', '--', path.resolve(__dirname, '../../bin/p2pd')])
+  await fs.rm(path.resolve(__dirname, '../../bin/p2pd')).catch(err => {
+    if (err.code !== 'ENOENT') {
+      throw err
+    }
+  })
 }

--- a/test/fixtures/clean.js
+++ b/test/fixtures/clean.js
@@ -4,7 +4,7 @@ const fs = require('fs/promises')
 const path = require('path')
 const execa = require('execa')
 
-module.exports = async function clean() {
+module.exports = async function clean () {
   await fs.rm(path.resolve(__dirname, '../../p2pd')).catch(err => {
     if (err.code !== 'ENOENT') {
       throw err

--- a/test/path.js
+++ b/test/path.js
@@ -2,16 +2,18 @@ var test = require('tape')
 var fs = require('fs')
 var path = require('path')
 var cp = require('child_process')
-var p2pd = path.join(__dirname, '..', 'bin', 'p2pd')
+const download = require('../src/download')
 
-test('ensure libp2p bin path exists', function (t) {
+test('ensure libp2p bin path exists', async function (t) {
   t.plan(4)
+  var p2pd = await download()
+  console.log("P2pd is", p2pd)
   fs.stat(p2pd, function (err, stats) {
     t.error(err, 'libp2p bin should stat witout error')
     cp.exec([p2pd, '--help'].join(' '), function (err, stdout, stderr) {
       t.error(err, 'libp2p bin runs without error')
-      t.true(stdout.indexOf('Usage') >= 0, 'libp2p bin executed')
-      t.false(stderr, 'no stderr output')
+      t.true(stderr.indexOf('Usage') >= 0, 'libp2p bin executed')
+      t.false(stdout, 'no stdout output')
     })
   })
 })


### PR DESCRIPTION
This was such a rabbit hole. I can't wait to get rid of these whole set of tools.

Challenges I ran into:

1. Where do I host these binaries so they are long lived on the IPFS network?
  1. First thought was to try web3.storage
  2. This gave me a cidv1 identifier. But this script doesn't handle cidv1. It only expects cidv0s.
  3. Fine, convert to cidv0.
  4. Mismatch in "expected SHA512". It's actually a sha256, but okay, whatever. Why?
  5. web3.storage slices the file in different size chunks than ipfs does. So when we ingest the file downloaded from the ipfs gateway we have no way of knowing what the chunks are so this will result in a different hash.
  6. Okay, I guess I can't use web3.storage.
  7. What about pinata? 
  8. That seems to work and chunk the files in a similar way. Great
2. Tests fail. 
  1. These tests rely on the tar.gz emitting a single `p2pd` file. This makes dealing with mutliple platforms hard. I changed it to accept a platform scoped binary (e.g. p2pd-darwin).
  2. The daemon now ([correctly](https://unix.stackexchange.com/questions/331611/do-progress-reports-logging-information-belong-on-stderr-or-stdout)) emits to stderr. This caused a test to fail in a confusing way.
  
  
Hopefully this unblocks @ckousik .