### PR TITLE
fix: switch to downloading from web3.storage

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -106,7 +106,7 @@ function cleanArguments (version, platform, arch, installPath) {
     cwd: process.env.INIT_CWD || process.cwd(),
     defaults: {
       version: version || latest,
-      distUrl: 'https://ipfs.io'
+      distUrl: 'https://w3s.link'
     }
   })
 


### PR DESCRIPTION
[web3.storage](https://web3.storage/)'s http gateway is like ipfs.io, just with caching so it should prevent the [intermittant CI failures](https://github.com/libp2p/js-libp2p/actions/runs/4105171858/jobs/7081659680) we sometimes see.

Note that we [check that we can create a CID from the downloaded file](https://github.com/libp2p/npm-go-libp2p/blob/master/src/download.js#L58-L67) that matches the one we requested so we verify the downloads.