### PR TITLE
add a got timeout in post-install.js

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -58,7 +58,7 @@ async function cachingFetchAndVerify (url, cid, options = {}) {
     console.info(`Downloading ${url} to ${cacheDir}`)
 
     const buf = await retry(async (attempt) => {
-      return await got(url).buffer()
+      return await got(url, { timeout: { request: 60000 }}).buffer()
     }, {
       retries,
       onFailedAttempt: async (err) => {


### PR DESCRIPTION
When the IPFS resource is not reachable for some reason, the `post-install.js` script will just hang forever because [`got` does not configure a timeout by default](https://github.com/sindresorhus/got/blob/main/documentation/6-timeout.md).

This happened to me today because I could not fetch `https://bafybeib3wtngarcyzl6ydokqf7k4qwa2z7thpr5mrtbg7f6s2gf2hrwmba.ipfs.dweb.link/` from my University's `eduroam` network, which was very frustrating as there was no useful message in the `npm install` progress.